### PR TITLE
supports multiple operations with multiple docs in one transaction

### DIFF
--- a/transaction-performer/pom.xml
+++ b/transaction-performer/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.couchbase</groupId>
     <artifactId>transaction</artifactId>
-    <version>syncgateway</version>
+    <version>performer</version>
     <repositories>
   <repository>
     <id>couchbase</id>

--- a/transaction-performer/pom.xml
+++ b/transaction-performer/pom.xml
@@ -6,7 +6,14 @@
 
     <groupId>com.couchbase</groupId>
     <artifactId>transaction</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>syncgateway</version>
+    <repositories>
+  <repository>
+    <id>couchbase</id>
+    <name>Couchbase Preview Repository</name>
+    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+  </repository>
+</repositories>
 
     <build>
         <plugins>

--- a/transaction-performer/src/main/java/com/couchbase/transaction.java
+++ b/transaction-performer/src/main/java/com/couchbase/transaction.java
@@ -28,6 +28,7 @@ public class transaction {
     private static ArrayList<TxnOperationId> txnOptObj = new ArrayList<TxnOperationId>();
     private static TxnOperationId txnobj;
     private static  String opt;
+    private static  String optDocid;
     
    
     public static void main(String[] args)  {
@@ -62,10 +63,9 @@ public class transaction {
         
         
         for(int i=0;i<optDocidArray.length;i++) {
-        	txnobj= new TxnOperationId();
         	opt = optDocidArray[i].split("-")[0];
-        	txnobj.txnOperation = opt;
-        	txnobj.txnDocID = optDocidArray[i].split("-")[1];
+        	optDocid = optDocidArray[i].split("-")[1];
+        	txnobj= new TxnOperationId(opt, optDocid);
         	txnOptObj.add(txnobj);
         	if(!operationList.contains(opt))
         		operationList.add(opt);
@@ -144,14 +144,21 @@ public class transaction {
         }
     }
 
+    private static void insert() {
+    	
+    }
     private static void Usage(){
         System.out.println("\n Usage: \n");
         System.out.println("Please enter the command in below format: \n");
-        System.out.println("java -cp <Relative location to this Jar> com.couchbase.transaction  clusterIp=<YourClusterIp> operationDocids=<RequiredTransactionOperation> docId=<DocumentId>  \n");
+        System.out.println("java -cp <Relative location to this Jar> com.couchbase.transaction  clusterIp=<YourClusterIp> operationDocids=<operation-docid> doccontent=<json body as string with single quotes enclosed>\n");
     }
     
-    private static class TxnOperationId{
+    public static class TxnOperationId{
     	String txnOperation=null, txnDocID=null;
+    	TxnOperationId(String txnOperation, String txnDocID){
+    		this.txnOperation = txnOperation;
+    		this.txnDocID = txnDocID;
+    	}
     }
 
 }

--- a/transaction-performer/src/main/java/com/couchbase/transaction.java
+++ b/transaction-performer/src/main/java/com/couchbase/transaction.java
@@ -1,8 +1,11 @@
 package com.couchbase;
 
+import java.util.UUID;
+
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.Collection;
 import com.couchbase.client.java.json.JsonObject;
+import com.couchbase.client.java.json.JsonArray;
 import com.couchbase.transactions.TransactionGetResult;
 import com.couchbase.transactions.Transactions;
 import com.couchbase.transactions.config.TransactionConfigBuilder;
@@ -13,17 +16,24 @@ public class transaction {
     private final static String CONTENT_NAME= "content";
     private final static String CLUSTER_LOGIN_USERNAME= "Administrator";
     private final static String CLUSTER_LOGIN_PASSWORD= "password";
-    private final static JsonObject INITIAL = JsonObject.create().put(CONTENT_NAME, "initial");
-    private final static JsonObject UPDATED = JsonObject.create().put(CONTENT_NAME, "updated");
-
+    //private final static JsonObject INITIAL;
+    //private final static JsonObject UPDATED = JsonObject.create().put(CONTENT_NAME, "updated");
+    private static JsonObject doccontent = JsonObject.create();
     private static String clusterIP;
-
+    private static String bucket;
+    private static String docstring;
+    private static String[] docidArray;
+    private static String[] removeDocidArray;
+    private static String temp_str;
+    private static JsonObject temp_obj;
+    private static String removeDocIds;
+ 
     public static void main(String[] args)  {
-      //  String randomId = UUID.randomUUID().toString();
+        String randomId = UUID.randomUUID().toString();
         String docId = null;
         String operation = "insert";
         for(String parameter : args) {
-            switch (parameter.split("=")[0].toLowerCase()) {
+			switch (parameter.split("=")[0].toLowerCase()) {
                 case "clusterip":
                     clusterIP= parameter.split("=")[1];
                     break;
@@ -32,14 +42,29 @@ public class transaction {
                     break;
                 case "docid":
                     docId = parameter.split("=")[1];
+                    docidArray = docId.split(",");
                     break;
+                case "removedocids":
+                    removeDocIds = parameter.split("=")[1];
+                    removeDocidArray = removeDocIds.split(",");
+                    break;
+                case "bucket":
+                	bucket = parameter.split("=")[1];
+                	break;
+                case "doccontent":
+                	docstring = parameter.split("=")[1];
+                	doccontent = JsonObject.fromJson(docstring);              	
+                	break;
                 default:
-                    System.out.println("Unknown parameter is given as input. Exiting");
+                    System.out.println("Unknown parameter is given as input. Exiting" + parameter);
                     Usage();
                     System.exit(-1);
             }
         }
-
+        if(doccontent.isEmpty()) {
+        	doccontent = JsonObject.create().put(CONTENT_NAME, "initial");
+        	doccontent.put("id", randomId);
+        }
 
         try{
 
@@ -47,43 +72,67 @@ public class transaction {
             Cluster cluster = Cluster.connect(clusterIP, CLUSTER_LOGIN_USERNAME, CLUSTER_LOGIN_PASSWORD);
 
             //Collection in which transactions will be executed
-            Collection collectionForTxnOperations = cluster.bucket("default").defaultCollection();
+            Collection collectionForTxnOperations = cluster.bucket(bucket).defaultCollection();
 
             TransactionConfigBuilder builder = TransactionConfigBuilder.create();  // Default transaction Configuration
             Transactions transactions = Transactions.create(cluster, builder);  // Transaction factory with default config is created on the cluster
-            String finalOperation = operation;
+            String[] operationList = operation.split(",");
             String finalDocId = docId;
+            
            /* if(finalOperation.equals("insert")){
                 finalDocId = randomId;
             }*/
-
+            
             transactions.run((ctx) -> {
                 TransactionGetResult result ;
-                switch(finalOperation){
+                for(int j=0;j<operationList.length;j++) {
+                switch(operationList[j]){
                     case "insert":
-                        ctx.insert(collectionForTxnOperations,finalDocId,INITIAL);
+                    	for(int i=0; i<docidArray.length; i++) {
+                    		doccontent.put("id", docidArray[i]);
+                        	doccontent.put("content", "doc_content"+docidArray[i]);
+                    		ctx.insert(collectionForTxnOperations,docidArray[i],doccontent);
+                    	}	
                         break;
                     case "get":
                         ctx.get(collectionForTxnOperations, finalDocId);
+                        result = ctx.get(collectionForTxnOperations, finalDocId);
+                        System.out.println("get of doc is " + result);
                         break;
                     case "getoptional":
                         ctx.getOptional(collectionForTxnOperations, finalDocId);
                         break;
                     case "replace":
-                        result =  ctx.get(collectionForTxnOperations, finalDocId);
-                        ctx.replace(result,UPDATED);
+                    	for(int i=0; i<docidArray.length; i++) {	
+                    		result =  ctx.get(collectionForTxnOperations, docidArray[i]);
+                    		temp_obj = result.contentAsObject();
+                    		temp_str = temp_obj.get("id").toString();
+                    		temp_obj.put("id", temp_str+"_updated");
+                    		temp_str = temp_obj.get("content").toString();
+                    		temp_obj.put("content", temp_str+"_updated");
+                            ctx.replace(result,temp_obj);
+                    	}         
                         break;
                     case "remove":
-                        result =  ctx.get(collectionForTxnOperations, finalDocId);
-                        ctx.remove(result);
+                    	for(int i=0; i<removeDocidArray.length; i++) {	
+                    		result =  ctx.get(collectionForTxnOperations, removeDocidArray[i]);
+                    		ctx.remove(result);
+                    	}    
                         break;
                     case "commit":
                         ctx.commit();
                         break;
                     case "rollback":
+                    	for(int i=0; i<docidArray.length; i++) {
+                    		doccontent.put("id", docidArray[i]);
+                        	doccontent.put("content", "doc_content"+docidArray[i]);
+                    		ctx.insert(collectionForTxnOperations,docidArray[i],doccontent);
+                    	}
                         ctx.rollback();
                         break;
+                    
                 }
+            }
             });
         } catch(TransactionFailed e) {
             System.out.println("Exception occurred while executing the transaction:" + e.getMessage());

--- a/transaction-performer/src/main/java/com/couchbase/transaction.java
+++ b/transaction-performer/src/main/java/com/couchbase/transaction.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.Collection;
 import com.couchbase.client.java.json.JsonObject;
+import com.couchbase.transactions.AttemptContext;
 import com.couchbase.transactions.TransactionGetResult;
 import com.couchbase.transactions.Transactions;
 import com.couchbase.transactions.config.TransactionConfigBuilder;
@@ -99,9 +100,7 @@ public class transaction {
                 for(int j=0;j<txnOptObj.size();j++) {
                 switch(txnOptObj.get(j).txnOperation){
                     case "insert":                    	
-                    	doccontent.put("id", txnOptObj.get(j).txnDocID);
-	                    doccontent.put("content", "doc_content"+txnOptObj.get(j).txnDocID);
-	                    ctx.insert(collectionForTxnOperations,txnOptObj.get(j).txnDocID,doccontent);
+                    	insert(ctx, txnOptObj.get(j).txnDocID, collectionForTxnOperations);
                         break;
                     case "get":
                         ctx.get(collectionForTxnOperations, finalDocId);
@@ -112,13 +111,7 @@ public class transaction {
                         ctx.getOptional(collectionForTxnOperations, finalDocId);
                         break;
                     case "replace":
-                    	result =  ctx.get(collectionForTxnOperations, txnOptObj.get(j).txnDocID);
-                        temp_obj = result.contentAsObject();
-                        temp_str = temp_obj.get("id").toString();
-                        temp_obj.put("id", temp_str+"_updated");
-                        temp_str = temp_obj.get("content").toString();
-                        temp_obj.put("content", temp_str+"_updated");
-                        ctx.replace(result,temp_obj);
+                    	replace(ctx, txnOptObj.get(j).txnDocID, collectionForTxnOperations);
                         break;
                     case "remove":
                     	result =  ctx.get(collectionForTxnOperations, txnOptObj.get(j).txnDocID);
@@ -142,8 +135,20 @@ public class transaction {
         }
     }
 
-    private static void insert() {
-    	
+    private static void insert(AttemptContext ctx, String txnid, Collection collectionForTxnOperations) {
+    	doccontent.put("id", txnid);
+        doccontent.put("content", "doc_content"+txnid);
+        ctx.insert(collectionForTxnOperations,txnid,doccontent);
+    }
+    private static void replace(AttemptContext ctx, String txnid, Collection collectionForTxnOperations) {
+    	TransactionGetResult result;
+    	result =  ctx.get(collectionForTxnOperations, txnid);
+        temp_obj = result.contentAsObject();
+        temp_str = temp_obj.get("id").toString();
+        temp_obj.put("id", temp_str+"_updated");
+        temp_str = temp_obj.get("content").toString();
+        temp_obj.put("content", temp_str+"_updated");
+        ctx.replace(result,temp_obj);
     }
     private static void Usage(){
         System.out.println("\n Usage: \n");

--- a/transaction-performer/src/main/java/com/couchbase/transaction.java
+++ b/transaction-performer/src/main/java/com/couchbase/transaction.java
@@ -1,11 +1,11 @@
 package com.couchbase;
 
+import java.util.ArrayList;
 import java.util.UUID;
 
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.Collection;
 import com.couchbase.client.java.json.JsonObject;
-import com.couchbase.client.java.json.JsonArray;
 import com.couchbase.transactions.TransactionGetResult;
 import com.couchbase.transactions.Transactions;
 import com.couchbase.transactions.config.TransactionConfigBuilder;
@@ -16,37 +16,31 @@ public class transaction {
     private final static String CONTENT_NAME= "content";
     private final static String CLUSTER_LOGIN_USERNAME= "Administrator";
     private final static String CLUSTER_LOGIN_PASSWORD= "password";
-    //private final static JsonObject INITIAL;
-    //private final static JsonObject UPDATED = JsonObject.create().put(CONTENT_NAME, "updated");
     private static JsonObject doccontent = JsonObject.create();
     private static String clusterIP;
     private static String bucket;
     private static String docstring;
-    private static String[] docidArray;
-    private static String[] removeDocidArray;
+    private static ArrayList<String> operationList = new ArrayList<String>();;
     private static String temp_str;
     private static JsonObject temp_obj;
-    private static String removeDocIds;
- 
+    private static String[] optDocidArray;
+    private static String operationDocids;
+    private static ArrayList<TxnOperationId> txnOptObj = new ArrayList<TxnOperationId>();
+    private static TxnOperationId txnobj;
+    private static  String opt;
+    
+   
     public static void main(String[] args)  {
         String randomId = UUID.randomUUID().toString();
         String docId = null;
-        String operation = "insert";
         for(String parameter : args) {
 			switch (parameter.split("=")[0].toLowerCase()) {
                 case "clusterip":
                     clusterIP= parameter.split("=")[1];
                     break;
-                case "operation":
-                    operation = parameter.split("=")[1];
-                    break;
-                case "docid":
-                    docId = parameter.split("=")[1];
-                    docidArray = docId.split(",");
-                    break;
-                case "removedocids":
-                    removeDocIds = parameter.split("=")[1];
-                    removeDocidArray = removeDocIds.split(",");
+                case "operationdocids":
+                    operationDocids = parameter.split("=")[1];
+                    optDocidArray = operationDocids.split(",");
                     break;
                 case "bucket":
                 	bucket = parameter.split("=")[1];
@@ -56,7 +50,7 @@ public class transaction {
                 	doccontent = JsonObject.fromJson(docstring);              	
                 	break;
                 default:
-                    System.out.println("Unknown parameter is given as input. Exiting" + parameter);
+                    System.out.println("Unknown parameter is given as input. Exiting " + parameter);
                     Usage();
                     System.exit(-1);
             }
@@ -65,7 +59,18 @@ public class transaction {
         	doccontent = JsonObject.create().put(CONTENT_NAME, "initial");
         	doccontent.put("id", randomId);
         }
-
+        
+        
+        for(int i=0;i<optDocidArray.length;i++) {
+        	txnobj= new TxnOperationId();
+        	opt = optDocidArray[i].split("-")[0];
+        	txnobj.txnOperation = opt;
+        	txnobj.txnDocID = optDocidArray[i].split("-")[1];
+        	txnOptObj.add(txnobj);
+        	if(!operationList.contains(opt))
+        		operationList.add(opt);
+        }
+        
         try{
 
             //Cluster on which transactions are to be executed
@@ -76,23 +81,21 @@ public class transaction {
 
             TransactionConfigBuilder builder = TransactionConfigBuilder.create();  // Default transaction Configuration
             Transactions transactions = Transactions.create(cluster, builder);  // Transaction factory with default config is created on the cluster
-            String[] operationList = operation.split(",");
-            String finalDocId = docId;
             
-           /* if(finalOperation.equals("insert")){
-                finalDocId = randomId;
-            }*/
+            String finalDocId = docId;
             
             transactions.run((ctx) -> {
                 TransactionGetResult result ;
-                for(int j=0;j<operationList.length;j++) {
-                switch(operationList[j]){
-                    case "insert":
-                    	for(int i=0; i<docidArray.length; i++) {
-                    		doccontent.put("id", docidArray[i]);
-                        	doccontent.put("content", "doc_content"+docidArray[i]);
-                    		ctx.insert(collectionForTxnOperations,docidArray[i],doccontent);
-                    	}	
+                for(int j=0;j<operationList.size();j++) {
+                switch(operationList.get(j)){
+                    case "insert":                    	
+                    	for(int i=0; i<txnOptObj.size(); i++) {
+                    		if(txnOptObj.get(i).txnOperation.equals("insert")) {
+	                    		doccontent.put("id", txnOptObj.get(i).txnDocID);
+	                        	doccontent.put("content", "doc_content"+txnOptObj.get(i).txnDocID);
+	                    		ctx.insert(collectionForTxnOperations,txnOptObj.get(i).txnDocID,doccontent);
+                    		}	
+                    	}
                         break;
                     case "get":
                         ctx.get(collectionForTxnOperations, finalDocId);
@@ -103,34 +106,32 @@ public class transaction {
                         ctx.getOptional(collectionForTxnOperations, finalDocId);
                         break;
                     case "replace":
-                    	for(int i=0; i<docidArray.length; i++) {	
-                    		result =  ctx.get(collectionForTxnOperations, docidArray[i]);
-                    		temp_obj = result.contentAsObject();
-                    		temp_str = temp_obj.get("id").toString();
-                    		temp_obj.put("id", temp_str+"_updated");
-                    		temp_str = temp_obj.get("content").toString();
-                    		temp_obj.put("content", temp_str+"_updated");
-                            ctx.replace(result,temp_obj);
-                    	}         
+                    	for(int i=0; i<txnOptObj.size(); i++) {
+                    		if(txnOptObj.get(i).txnOperation.equals("replace")) {
+                    			result =  ctx.get(collectionForTxnOperations, txnOptObj.get(i).txnDocID);
+                        		temp_obj = result.contentAsObject();
+                        		temp_str = temp_obj.get("id").toString();
+                        		temp_obj.put("id", temp_str+"_updated");
+                        		temp_str = temp_obj.get("content").toString();
+                        		temp_obj.put("content", temp_str+"_updated");
+                        		ctx.replace(result,temp_obj);
+                    		}	
+                    	}
                         break;
                     case "remove":
-                    	for(int i=0; i<removeDocidArray.length; i++) {	
-                    		result =  ctx.get(collectionForTxnOperations, removeDocidArray[i]);
-                    		ctx.remove(result);
-                    	}    
+                    	for(int i=0; i<txnOptObj.size(); i++) {
+                    		if(txnOptObj.get(i).txnOperation.equals("remove")) {
+                    			result =  ctx.get(collectionForTxnOperations, txnOptObj.get(i).txnDocID);
+                        		ctx.remove(result);
+                    		}	
+                    	}
                         break;
                     case "commit":
                         ctx.commit();
                         break;
                     case "rollback":
-                    	for(int i=0; i<docidArray.length; i++) {
-                    		doccontent.put("id", docidArray[i]);
-                        	doccontent.put("content", "doc_content"+docidArray[i]);
-                    		ctx.insert(collectionForTxnOperations,docidArray[i],doccontent);
-                    	}
                         ctx.rollback();
                         break;
-                    
                 }
             }
             });
@@ -146,6 +147,12 @@ public class transaction {
     private static void Usage(){
         System.out.println("\n Usage: \n");
         System.out.println("Please enter the command in below format: \n");
-        System.out.println("java -cp <Relative location to this Jar> com.couchbase.transaction  clusterIp=<YourClusterIp> operation=<RequiredTransactionOperation> docId=<DocumentId>  \n");
+        System.out.println("java -cp <Relative location to this Jar> com.couchbase.transaction  clusterIp=<YourClusterIp> operationDocids=<RequiredTransactionOperation> docId=<DocumentId>  \n");
     }
+    
+    private static class TxnOperationId{
+    	String txnOperation=null, txnDocID=null;
+    }
+
 }
+


### PR DESCRIPTION
changes : It can take multiple operations . SGW needs 1 doc update and 2nd doc removal in same transaction. In order to support that , I added multiple operations for each request
                  It can take multiple docs for each transaction. client for this transaction app can send as many docs as they can.

usuage after changes :  For replace and remove operation at same request -> java -cp transaction-syncgateway.jar com.couchbase.transaction clusterip=192.168.33.10 operation=replace,remove docid=san1,san2,san3 removeDocids=san2 bucket=travel-sample doccontent='{"_id": "transaction-sync-id2", "content": "doc3", "channels": ["TRANSACTIONS"]}'

For multiple docs in one transactions -> java -cp transaction-syncgateway.jar com.couchbase.transaction clusterip=192.168.33.10 operation=insert docid=san1,san2,san3 bucket=travel-sample doccontent='{"_id": "transaction-sync-id2", "content": "doc3", "channels": ["TRANSACTIONS"]}'
                 