### PR TITLE
Fix divide by zero error if totalTestCount is 0

### DIFF
--- a/runanalyzer/runanalyzer.go
+++ b/runanalyzer/runanalyzer.go
@@ -659,7 +659,11 @@ func getreruntotalbuildcycleduration(buildN string) int {
 				//	key, totalTestCount, totalFailCount, totalAborted, totalFailed, totalUnstable, totalSuccess, totalDuration, len(value), totalJobs,
 				//	totalRuns, totalReruns, reranJobCount)
 				var totalPassCount = totalTestCount - totalFailCount
-				var totalPassRate = (totalPassCount * 100) / totalTestCount
+				var totalPassRate = 0
+				// prevent divide by zero
+				if totalPassCount > 0 {
+					totalPassRate = (totalPassCount * 100) / totalTestCount
+				}
 				var totalComps = len(value)
 				hours := math.Floor(float64(totalGrandDuration) / 1000 / 60 / 60)
 				secs := totalDuration % (1000 * 60 * 60)
@@ -964,7 +968,11 @@ func getreruntotalbuildcycledurationclocktime(buildN string) int {
 				//	key, totalTestCount, totalFailCount, totalAborted, totalFailed, totalUnstable, totalSuccess, totalDuration, len(value), totalJobs,
 				//	totalRuns, totalReruns, reranJobCount)
 				var totalPassCount = totalTestCount - totalFailCount
-				var totalPassRate = (totalPassCount * 100) / totalTestCount
+				var totalPassRate = 0
+				// prevent divide by zero
+				if totalPassCount > 0 {
+					totalPassRate = (totalPassCount * 100) / totalTestCount
+				}
 				var totalComps = len(value)
 				hours := math.Floor(float64(totalGrandDuration) / 1000 / 60 / 60)
 				secs := totalGrandDuration % (1000 * 60 * 60)


### PR DESCRIPTION
http://qa.sc.couchbase.com/job/reruntestcyclesummaryreport/874/console

panic: runtime error: integer divide by zero

goroutine 1 [running]:
main.getreruntotalbuildcycleduration(0x7ffc4d295886, 0xc, 0x0)
	/root/productivitynautomation_latest/productivitynautomation/runanalyzer/runanalyzer.go:662 +0x3925
main.main()
	/root/productivitynautomation_latest/productivitynautomation/runanalyzer/runanalyzer.go:243 +0x1426

Should we also handle rerunsRate on lines 682 and 985?