### PR TITLE
CBQE-6556: dynamic VM - release command issue

### DIFF
--- a/syshealth/dynvmservice.py
+++ b/syshealth/dynvmservice.py
@@ -308,8 +308,8 @@ def getservers_service(username):
                 for ip in per_xen_host_res:
                     merged_vms_list.append(ip)
                 log.info(per_xen_host_res)
-                # increase index by requested amount
-                vm_name_suffix_index = int(vm_name_suffix_index) + int(per_xen_host_vms)
+                # increase index by success amount (could be less than requested)
+                vm_name_suffix_index += len(per_xen_host_res)
                 # decrease need_vms by success amount (could be less than requested)
                 need_vms = need_vms - len(per_xen_host_res)
 


### PR DESCRIPTION
If some vms were created successfully and some failed, the index was increased by the requested amount (not only successful amount). In the case of requesting 4 vms from host 1 where 2 succeed and 2 fail, host 2 will use indices 5,6 not 3,4. When deleting, vms with indices 1-4 will be deleted ignoring 5,6