### PR TITLE
Add parameter to rerun job on different build

### DIFF
--- a/jenkins/rerun_failed_jobs.py
+++ b/jenkins/rerun_failed_jobs.py
@@ -77,6 +77,7 @@ def parse_arguments():
     parser.add_option("--maintain-threshold", dest="maintain_threshold", help="Check pool availability every time before dispatching", action="store_true", default=False)
     parser.add_option("--override-dispatcher", dest="override_dispatcher", default="test_suite_dispatcher_multiple_pools")
     parser.add_option("--failed-jobs", dest="failed_jobs", default=False, action="store_true")
+    parser.add_option("--rerun-build", dest="rerun_build", help="Couchbase server build to rerun with, same as --build if not supplied")
 
     options, _ = parser.parse_args()
 
@@ -656,6 +657,9 @@ def rerun_jobs(queue, server: Jenkins, cluster, pool_thresholds_hit, options):
 
             if 'dispatcher_params' not in parameters:
 
+                if options.rerun_build and "version_number" in parameters and parameters["version_number"] == options.build:
+                    parameters["version_number"] = options.rerun_build
+
                 if not options.noop:
                     server.build_job(job_name, parameters)
 
@@ -679,6 +683,9 @@ def rerun_jobs(queue, server: Jenkins, cluster, pool_thresholds_hit, options):
                 if job['result'] != "ABORTED":
                     # this is a rerun
                     dispatcher_params['fresh_run'] = False
+
+                if options.rerun_build and "version_number" in dispatcher_params and dispatcher_params["version_number"] == options.build:
+                    dispatcher_params["version_number"] = options.rerun_build
 
                 dispatcher_name = job_name_from_url(options.jenkins_url, dispatcher_params['dispatcher_url'])
 


### PR DESCRIPTION
(env) jakerawsthorne@REML0715 jenkins % python rerun_failed_jobs.py -n --build 7.0.0-4554 --previous-builds 7.0.0-4502 --strategy regression --failed --max-reruns 10

2021-03-05 13:09:19,854 - rerun_failed_jobs - INFO - Triggered test_suite_dispatcher_multiple_pools with parameters {'OS': 'centos', 'version_number': '7.0.0-4554', 'suite': '12hr_weekly', 'component': 'fts', 'subcomponent': 'defmap-scorch-multicollections_7.0_P0', 'serverPoolId': 'regression', 'addPoolId': 'elastic-fts', 'extraParameters': '', 'Test': False, 'url': '', 'branch': 'master', 'cherrypick': 'git fetch "http://review.couchbase.org/testrunner" refs/changes/40/147640/21 && git cherry-pick FETCH_HEAD', 'retries': '0', 'fresh_run': False, 'rerun_params': '-d failed=http://qa.sc.couchbase.com/job/test_suite_executor/321654/', 'executor_suffix': '', 'executor_job_parameters': '', 'check_vm': True}

(env) jakerawsthorne@REML0715 jenkins % python rerun_failed_jobs.py -n --build 7.0.0-4554 --previous-builds 7.0.0-4502 --strategy regression --failed --max-reruns 10 --rerun-build 7.0.0-4600

2021-03-05 13:10:39,688 - rerun_failed_jobs - INFO - Triggered test_suite_dispatcher_multiple_pools with parameters {'OS': 'centos', 'version_number': '7.0.0-4600', 'suite': '12hr_weekly', 'component': 'fts', 'subcomponent': 'defmap-scorch-multicollections_7.0_P0', 'serverPoolId': 'regression', 'addPoolId': 'elastic-fts', 'extraParameters': '', 'Test': False, 'url': '', 'branch': 'master', 'cherrypick': 'git fetch "http://review.couchbase.org/testrunner" refs/changes/40/147640/21 && git cherry-pick FETCH_HEAD', 'retries': '0', 'fresh_run': False, 'rerun_params': '-d failed=http://qa.sc.couchbase.com/job/test_suite_executor/321654/', 'executor_suffix': '', 'executor_job_parameters': '', 'check_vm': True}