### PR TITLE
CBQE-6821: Dynamic VMs: Overprovisioning of VMs on Xen Hosts

### DIFF
--- a/syshealth/dynvmservice.py
+++ b/syshealth/dynvmservice.py
@@ -737,7 +737,7 @@ def create_vm(session, os_name, template, network, new_vm_name, cpus="default", 
         log.debug("  Selected template: {}".format(session.xenapi.VM.get_name_label(template_ref)))
 
         # Retries when 169.x address received
-        ipaddr_max_retries = 3
+        ipaddr_max_retries = 1
         retry_count = 1
         is_local_ip = True
         vm_ip_addr = ""

--- a/syshealth/dynvmservice.py
+++ b/syshealth/dynvmservice.py
@@ -1077,7 +1077,7 @@ def get_available_count(session, os="centos", xen_host=None):
         psize, valloc, fsize = get_host_disks(session, 'SCSIid')
     else:
         psize, valloc, fsize = get_host_disks(session, xen_host['host.storage.name'])
-    xen_cpu_count_free, xen_cpu_count_total, xen_memory_free_gb, xen_memory_total_gb = \
+    xen_cpu_count_free, xen_memory_free_gb, xen_cpu_count_total, xen_memory_total_gb = \
         get_host_usage(session)
     log.info(
         'Host free cpus={},free memory={},total cpus={},total memory={}'.format(xen_cpu_count_free, xen_memory_free_gb, xen_cpu_count_total, xen_memory_total_gb))
@@ -1143,7 +1143,7 @@ def get_vms_usage(session):
 
 
 def get_host_details(session):
-    xen_cpu_count_free, xen_cpu_count_total, xen_memory_free_gb, xen_memory_total_gb = \
+    xen_cpu_count_free, xen_memory_free_gb, xen_cpu_count_total, xen_memory_total_gb = \
         get_host_usage(session)
     log.info("{},{},{},{}".format(xen_cpu_count_free, xen_memory_free_gb, xen_cpu_count_total,
                                   xen_memory_total_gb))


### PR DESCRIPTION
Free memory was being interpreted as free cpu leading to overprovisioning